### PR TITLE
update neccesitate by changes in async_upnp_client used in homeassistant

### DIFF
--- a/hassfeld/upnp.py
+++ b/hassfeld/upnp.py
@@ -3,7 +3,7 @@ import asyncio
 import sys
 
 from aiohttp import client_exceptions
-from async_upnp_client import UpnpFactory
+from async_upnp_client.client_factory import UpnpFactory
 from async_upnp_client.aiohttp import AiohttpRequester, AiohttpSessionRequester
 
 from .common import log_error, log_info

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.rst", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="hassfeld",
-    version="0.3.10-alpha1",
+    version="0.3.11-alpha1",
     description="Integration of Raumfeld into Home Assistant",
     long_description=long_description,
     long_description_content_type="text/x-rst",
@@ -19,7 +19,7 @@ setuptools.setup(
     python_requires='>=3.5',
     install_requires=[
         "aiohttp",
-        "async_upnp_client>=0.15.0",
+        "async_upnp_client>=0.27",
         "requests",
         "xmltodict",
     ]


### PR DESCRIPTION
Homeassistant now uses async_upnp_client 0.27 which moved UpnpFactory to it's own submodule.

To make teufel_raumfeld and hassfeld work again with homeassistant 2022.04 and newer, these changes are necessary.

This should fix https://github.com/B5r1oJ0A9G/teufel_raumfeld/issues/31

This pull-request is super simple and the code is basically copied from the same fix for openhomedevice https://github.com/bazwilliams/openhomedevice/compare/2.0.1...2.0.2. Yet be aware I won't actually have the opportunity to actually test it for a few more days.
