### PR TITLE
ci: downstream integration test against teufel_raumfeld

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,3 +47,27 @@ jobs:
         with:
           name: dist
           path: dist/
+
+  downstream-test:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - uses: actions/checkout@v4
+        with:
+          repository: B5r1oJ0A9G/teufel_raumfeld
+          path: teufel_raumfeld
+      - uses: astral-sh/setup-uv@v5
+      - name: Install teufel_raumfeld with local hassfeld
+        run: |
+          cd teufel_raumfeld
+          uv sync --extra ha
+          uv pip install ../dist/hassfeld-*.whl
+          uv pip install -e .
+      - name: Run teufel_raumfeld tests
+        run: |
+          cd teufel_raumfeld
+          uv run pytest tests/ -v


### PR DESCRIPTION
## Summary
Add a `downstream-test` job to hassfeld's CI that tests every change against teufel_raumfeld:

1. Build hassfeld wheel (already done by `build` job)
2. Clone teufel_raumfeld
3. Install the local wheel + teufel_raumfeld dependencies
4. Run teufel_raumfeld's full test suite (81 tests)

## Why
Catches breaking changes to the main consumer before a release is published. No cross-repo webhooks, no secrets sharing — everything runs in hassfeld's own CI.